### PR TITLE
Added support for more keybinds and removed some duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 Add the content of the `keymap.cson` file (or store the file) in `~/.atom` to get Emacs key bindings in
 Atom editor (http://atom.io).
+
+Note: If you want a emacs-like file finder (when using 'ctrl-x ctrl-f') then install the [Advanced-open-file](https://atom.io/packages/advanced-open-file) package. Then change the 'ctrl-x ctrl-f' command in keymap.cson to 'advanced-open-file:toggle'

--- a/keymap.cson
+++ b/keymap.cson
@@ -7,16 +7,29 @@
   'ctrl-x b': 'fuzzy-finder:toggle-buffer-finder'
   # find resource (Eclipse like)
   'ctrl-shift-t': 'fuzzy-finder:toggle-file-finder'
-  'ctrl-x ctrl-f': 'application:open-file'
-  'ctrl-x ctrl-n': 'application:new-file'
-  'ctrl-x ctrl-d': 'application:open-folder'
+  'ctrl-x': 'unset!'
+  'ctrl-x ctrl-n': 'application:new-file' # could disable if you have advanced-open-file package
+  'ctrl-x ctrl-d': 'application:open-folder' # should disable if you have advanced-open-file package
+  
+  'ctrl-x ctrl-f': 'fuzzy-finder:toggle-file'
+
+  # If you want the "find a file" command to open your native file browser
+  # 'ctrl-x ctrl-f': 'application:open-file'
+
+  # If you want to use the "advanced open file" package (this emulates emacs)
+  # 'ctrl-x ctrl-f': 'advanced-open-file:toggle'
+
   'ctrl-g': 'core:cancel'
-  'ctrl-x k': 'core:close'
+  'ctrl-x ctrl-c': 'application:quit'
+  'ctrl-x k': 'pane:close'
   'ctrl-x 3': 'pane:split-right'
   'ctrl-x 2': 'pane:split-down'
-  'ctrl-x 0': 'pane:close'
   'ctrl-x 1': 'pane:close-other-items'
   'ctrl-x o': 'window:focus-next-pane'
+  'ctrl-f': 'core:move-right'
+  'ctrl-b': 'core:move-left'
+  'ctrl-n': 'core:move-down'
+  'ctrl-p': 'core:move-up'
 
 'atom-text-editor:not([mini])':
   # navigation
@@ -30,10 +43,7 @@
   'escape >': 'core:move-to-bottom'
   'alt-<': 'core:move-to-top'
   'alt->': 'core:move-to-bottom'
-  'ctrl-f': 'core:move-right'
-  'ctrl-b': 'core:move-left'
-  'ctrl-n': 'core:move-down'
-  'ctrl-p': 'core:move-up'
+
   'alt-f': 'editor:move-to-end-of-word'
   'alt-b': 'editor:move-to-beginning-of-word'
   'ctrl-v': 'core:page-down'
@@ -44,7 +54,10 @@
   'ctrl-d': 'core:delete'
   'ctrl-k': 'editor:cut-to-end-of-line'
   'ctrl-x u': 'core:undo'
-  'ctrl-/': 'editor:toggle-line-comments'
+  'ctrl-/': 'core:undo'
+  'ctrl-_': 'core:undo'
+  'ctrl-c ctrl-c': 'editor:toggle-line-comments'
+
   # copy/paste
   'ctrl-y': 'core:paste'
   'ctrl-w': 'core:cut'
@@ -57,7 +70,10 @@
   # file
   'ctrl-x ctrl-s': 'core:save'
   'ctrl-x ctrl-w': 'core:save-as'
-  'ctrl-x ctrl-f': 'application:open-file'
+  # 'ctrl-x ctrl-f': 'advanced-open-file:toggle' #duplicate
+  # 'ctrl-x ctrl-f': 'application:open-file' #duplicate
+
+
   'ctrl-shift-t': 'fuzzy-finder:toggle-file-finder'
   # tab/buffers
   'ctrl-x b': 'fuzzy-finder:toggle-buffer-finder'
@@ -66,9 +82,10 @@
   'alt-x': 'command-palette:toggle'
   'ctrl-shift-c': 'command-palette:toggle'
   # application
-  'ctrl-g': 'core:cancel'
-  'ctrl-x k': 'pane:close'
-  'ctrl-x ctrl-c': 'application:quit'
+  #'ctrl-g': 'core:cancel' #duplicate
+  #'ctrl-x k': 'pane:close' #duplicate
+  #'ctrl-x ctrl-c': 'application:quit' #duplicate
+  
   # other
    # ctrl-t           find any file in the project
    # ctrl-,           open settings view


### PR DESCRIPTION
Added 'ctrl-/' and 'ctrl-_' as undo
unbinded 'ctrl-x' which caused problems
Moved normal navigation keys in emacs to 'body' so that they work in the command palette and other pop-ups too.
'ctrl-x k' closes the pane, not all of the panes now.

Changed 'ctrl-x ctrl-f' to use fuzzy finder. This is because the normal open-file dialogue is optimized to use mouse, but fuzzy finder works better with a keyboard.
The best solution is to install the "advanced open file" package which works similarly to "ctrl-x ctrl-f" in emacs.

Added 'ctrl-c ctrl-c' to comment/uncomment code.